### PR TITLE
fix radec endpoint radius units, add cos(dec) term

### DIFF
--- a/build_spectra.py
+++ b/build_spectra.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env ipython3
 import os
 import desispec.io, desispec.spectra
-from math import sqrt
+from math import sqrt, radians, cos
 from typing import List, Tuple
 from models import *
 from desispec.spectra import Spectra
@@ -49,7 +49,9 @@ def radec(release: DataRelease, ra: float, dec: float, radius: float) -> Spectra
     targets = retrieve_targets(release)
 
     def distfilter(target: Target) -> bool:
-        return sqrt((ra - target.ra) ** 2 + (dec - target.dec) ** 2) <= radius/3600
+        ra_diff = (ra - target.ra)*cos(radians(dec))
+        dec_diff = (dec - target.dec)
+        return sqrt(ra_diff**2 + dec_diff**2) < radius/3600
 
     relevant_targets = [
         t for t in targets if distfilter(t)

--- a/build_spectra.py
+++ b/build_spectra.py
@@ -49,11 +49,12 @@ def radec(release: DataRelease, ra: float, dec: float, radius: float) -> Spectra
     targets = retrieve_targets(release)
 
     def distfilter(target: Target) -> bool:
-        return sqrt((ra - target.ra) ** 2 + (dec - target.dec) ** 2) <= radius
+        return sqrt((ra - target.ra) ** 2 + (dec - target.dec) ** 2) <= radius/3600
 
     relevant_targets = [
         t for t in targets if distfilter(t)
     ]  # TODO probably inefficient
+    log(f'Retrieving {len(relevant_targets)} targets')
     spectra = retrieve_target_spectra(release, relevant_targets)
     return desispec.spectra.stack(spectra)
 


### PR DESCRIPTION
This PR fixes a units issue with the radius parameter for the radec endpoint.  It should be in arcsec = degrees/3600.  Although it may seem somewhat odd to specify the ra,dec center in degrees and the search radius in different units, this is reasonably common in astronomy since an arcsec is about the scale that a ground-based telescope can resolve different objects on the sky, so it is a convenient unit for a search radius, while specifying it in degrees risks typos on how many zeros after the decimal place you need when you mean 1/3600 = 0.000278.

It also adds a cos(dec) correction on the ra difference to account for the spherical geometry that one degree of ra (longitude) difference is a different actual angle on the sky as you change declination (latitude).  e.g. at dec=60 degrees, moving 2 degrees in dec is the same angle as moving 1 degree in dec at the equator.

I also split the calculation into several intermediate steps, since I went through several bugs on parentheses placement before I got it right, and even then still found it difficult to read that they were actually correct given the extra cos(radians(dec)) term.  So I split it apart further to make it more obvious (to me at least).

Disclaimer: this ra/dec difference calculation doesn't yet handle the ra=0/360 wraparound correctly.  There are good ways to do that, but they are best implemented by vectorizing the calculation which will also address the pre-existing "TODO probably inefficient" comment, so I'm not changing that here yet.