### PR TITLE
more generic default config location

### DIFF
--- a/models.py
+++ b/models.py
@@ -12,7 +12,8 @@ import utils
 # Models and constants
 
 # CONFIG_FILE = f"{os.getenv('HOME')}/.config/desi-api.toml"
-CONFIG_FILE = "/home/vivien/d/urap/desi-api/docker-utilities/default.toml"
+# CONFIG_FILE = "/home/vivien/d/urap/desi-api/docker-utilities/default.toml"
+CONFIG_FILE = os.path.dirname(__file__)+"/docker-utilities/default.toml"
 with open(CONFIG_FILE, "rb") as conf:
     CONFIG = tomllib.load(conf)
 


### PR DESCRIPTION
Changes the hardcoded CONFIG_FILE location into a lookup relative to the directory location of the code.  I'm open to other more robust ways of doing this, but let's do something that isn't a hardcoded default.